### PR TITLE
fix xiaozhi audio_input task and shackchan task issue

### DIFF
--- a/firmware/main/hal/hal.cpp
+++ b/firmware/main/hal/hal.cpp
@@ -164,7 +164,7 @@ void Hal::startXiaozhi()
     });
 
     // Start stackchan update task
-    xTaskCreate(_stackchan_update_task, "stackchan", 4096, NULL, 5, NULL);
+    xTaskCreatePinnedToCore(_stackchan_update_task, "stackchan", 4096, NULL, 5, NULL, 1);
 
     hal_bridge::start_xiaozhi_app();
 }


### PR DESCRIPTION
1. Both audio_input  task and shackchan task may run on core 0.
2. Delayed scheduling of the xiaozhi audio_input task can lead to inaccurate ASR audio reception.