### PR TITLE
fix(server): use relative SQLite path so dev mode works without root

### DIFF
--- a/server/manifest/config/config.yaml
+++ b/server/manifest/config/config.yaml
@@ -12,4 +12,4 @@ logger:
 # https://goframe.org/docs/core/gdb-config-file
 database:
   default:
-    link: "sqlite::@file(/stackChan.sqlite)"
+    link: "sqlite::@file(./stackChan.sqlite)"


### PR DESCRIPTION
The config.yaml shipped in the repo points the SQLite link at
/stackChan.sqlite (filesystem root). That works in the provided Alpine
Dockerfile, which sets WORKDIR=/app and runs as root, but it prevents
any non-root developer from starting ./StackChan locally: GoFrame fails
to open the DB file on boot because / is not writable.

Switching to ./stackChan.sqlite resolves to WORKDIR in both situations
(local go run / go build and the Docker container), so the stock
command "go build && ./StackChan" finally works out of the box.
