### PR TITLE
refactor(firmware): route account and app_center URLs through secret_logic

### DIFF
--- a/firmware/main/hal/hal_account.cpp
+++ b/firmware/main/hal/hal_account.cpp
@@ -17,9 +17,20 @@ static const std::string_view _setting_ns              = "account";
 static const std::string_view _setting_username_key    = "username";
 static const std::string_view _setting_device_name_key = "device_name";
 
-static const std::string_view _get_user_account_info_url    = "http://47.113.125.164:12800/stackChan/device/user";
-static const std::string_view _get_device_info_url          = "http://47.113.125.164:12800/stackChan/device/info";
-static const std::string_view _unbind_user_account_info_url = "http://47.113.125.164:12800/stackChan/device/unbind";
+static std::string get_user_account_info_url()
+{
+    return secret_logic::get_server_url() + "/stackChan/device/user";
+}
+
+static std::string get_device_info_url()
+{
+    return secret_logic::get_server_url() + "/stackChan/device/info";
+}
+
+static std::string get_unbind_user_account_info_url()
+{
+    return secret_logic::get_server_url() + "/stackChan/device/unbind";
+}
 
 static bool request_authorized_get(std::string_view token, std::string_view url, std::string &response,
                                    std::function<void(std::string_view)> onLog)
@@ -58,7 +69,8 @@ static bool fetch_username(std::string_view token, std::string &username, std::f
     onLog("Updating user account info...");
 
     std::string response;
-    if (!request_authorized_get(token, _get_user_account_info_url, response, onLog)) {
+    const std::string url = get_user_account_info_url();
+    if (!request_authorized_get(token, url, response, onLog)) {
         return false;
     }
 
@@ -101,7 +113,8 @@ static bool fetch_device_name(std::string_view token, std::string &deviceName,
     onLog("Updating device info...");
 
     std::string response;
-    if (!request_authorized_get(token, _get_device_info_url, response, onLog)) {
+    const std::string url = get_device_info_url();
+    if (!request_authorized_get(token, url, response, onLog)) {
         return false;
     }
 
@@ -193,7 +206,7 @@ bool Hal::unbindAccount(std::function<void(std::string_view)> onLog)
     mclog::tagInfo(_tag, "requesting to unbind account...");
     onLog("Unbinding account...");
 
-    if (!http->Open("POST", std::string(_unbind_user_account_info_url))) {
+    if (!http->Open("POST", get_unbind_user_account_info_url())) {
         mclog::tagError(_tag, "failed to open http request");
         onLog("Failed to connect to server");
         return false;

--- a/firmware/main/hal/hal_app_center.cpp
+++ b/firmware/main/hal/hal_app_center.cpp
@@ -5,6 +5,7 @@
  */
 #include "hal.h"
 #include "utils/ota/ota.h"
+#include "utils/secret_logic/secret_logic.h"
 #include <mooncake_log.h>
 #include <memory>
 #include <board.h>
@@ -12,7 +13,10 @@
 
 static const std::string_view _tag = "HAL-AppCenter";
 
-static const std::string_view _app_info_list_url = "http://47.113.125.164:12800/stackChan/apps";
+static std::string get_app_info_list_url()
+{
+    return secret_logic::get_server_url() + "/stackChan/apps";
+}
 
 static const char *get_json_string(cJSON *item, std::initializer_list<const char *> keys)
 {
@@ -33,7 +37,7 @@ app_center::AppInfoList_t Hal::fetchAppList()
     auto network = board.GetNetwork();
 
     auto http = network->CreateHttp(0);
-    if (!http->Open("GET", std::string(_app_info_list_url))) {
+    if (!http->Open("GET", get_app_info_list_url())) {
         mclog::tagError(_tag, "failed to open http connection");
         return app_list;
     }


### PR DESCRIPTION
Align hal_account.cpp and hal_app_center.cpp with hal_ws_avatar.cpp:66,
which already builds the StackChan server URL by composing
secret_logic::get_server_url() with the route path.

Before this change, the four remaining HTTP endpoints were hard-coded to
the production IP (http://47.113.125.164:12800), preventing custom
server-url overrides from taking effect on three of the four services.
Now all four HAL call sites go through the same weak-linked
secret_logic::get_server_url() extension point.

No functional change intended: the default return of get_server_url()
still resolves to the server URL configured at build time via the
secret_logic override (or the stub localhost:3000 when no override is
provided).
