### PR TITLE
feat(firmware): add CONFIG_STACKCHAN_SERVER_URL Kconfig option

### DIFF
--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1,3 +1,16 @@
+menu "StackChan Server"
+
+config STACKCHAN_SERVER_URL
+    string "StackChan server base URL"
+    default "http://47.113.125.164:12800"
+    help
+        Base URL (scheme + host + port, no trailing slash) of the StackChan backend.
+        The HAL composes endpoint paths like /stackChan/device/user,
+        /stackChan/apps and /stackChan/ws from this base. Override in your
+        sdkconfig.defaults.local to point at a self-hosted deployment.
+
+endmenu
+
 menu "Xiaozhi Assistant"
 
 config OTA_URL

--- a/firmware/main/hal/utils/secret_logic/secret_logic.cpp
+++ b/firmware/main/hal/utils/secret_logic/secret_logic.cpp
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: MIT
  */
 #include "secret_logic.h"
+#include <sdkconfig.h>
 
 namespace secret_logic {
 
 __attribute__((weak)) std::string get_server_url()
 {
+#ifdef CONFIG_STACKCHAN_SERVER_URL
+    return CONFIG_STACKCHAN_SERVER_URL;
+#else
     return "http://localhost:3000";
+#endif
 }
 
 __attribute__((weak)) std::string generate_auth_token()


### PR DESCRIPTION
Expose the StackChan backend base URL as a Kconfig string so it can be
overridden via menuconfig or sdkconfig.defaults.local without patching
source files. This follows the same pattern as the existing
CONFIG_OTA_URL option used by the Xiaozhi Assistant pipeline.

The weak-linked secret_logic::get_server_url() now returns
CONFIG_STACKCHAN_SERVER_URL when defined, and keeps the previous
localhost:3000 stub as a fallback for builds that omit the config.

The default value equals the current production server, so firmware
builds without an explicit override keep talking to the same backend
they do today (no regression).

Intended usage with this option relies on hal_account.cpp and
hal_app_center.cpp going through secret_logic::get_server_url() as well
(see the companion refactor). Until that lands, only hal_ws_avatar.cpp
honours the override.
