### PR TITLE
feat(firmware): make EzData integration optional via CONFIG_USE_EZDATA

### DIFF
--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1,3 +1,20 @@
+menu "StackChan Features"
+
+config USE_EZDATA
+    bool "Enable EzData integration"
+    default y
+    help
+        When enabled (default, production behaviour), the firmware installs
+        the EzData Mooncake app and connects to M5Stack's cloud at
+        uiflow2.m5stack.com (MQTT) and ezdata2.m5stack.com (HTTP) for
+        cross-device parameter sync.
+
+        Disable when self-hosting the StackChan backend and you do not
+        need EzData. This avoids retry noise in the logs and prevents any
+        traffic from leaving for M5Stack cloud services.
+
+endmenu
+
 menu "Xiaozhi Assistant"
 
 config OTA_URL

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -32,7 +32,9 @@ extern "C" void app_main(void)
     GetMooncake().installApp(std::make_unique<AppAvatar>());
     GetMooncake().installApp(std::make_unique<AppEspnowControl>());
     GetMooncake().installApp(std::make_unique<AppAppCenter>());
+#if CONFIG_USE_EZDATA
     GetMooncake().installApp(std::make_unique<AppEzdata>());
+#endif
     GetMooncake().installApp(std::make_unique<AppDance>());
     GetMooncake().installApp(std::make_unique<AppSetup>());
 


### PR DESCRIPTION
Introduce a Kconfig boolean, defaulted to y, that gates the installation
of the EzData Mooncake app in main.cpp. When disabled, the firmware
never instantiates AppEzdata, so it never calls
Hal::startEzDataService() and therefore never opens the MQTT connection
to uiflow2.m5stack.com nor the HTTPS upload to ezdata2.m5stack.com.

The default is y to preserve the existing production behaviour: builds
that do not touch the new option keep shipping EzData as today.

This is useful for self-hosted deployments that want zero outbound
traffic to M5Stack cloud services, and for privacy-sensitive builds
where cross-device parameter sync is not needed.

The startEzDataService implementation itself is left untouched so the
API surface stays stable for any downstream code that references it.
