### PR TITLE
feat(firmware): auto-load sdkconfig.defaults.local overlay when present

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -8,5 +8,16 @@ add_definitions(-DFIRMWARE_VERSION=\"${PROJECT_VER}\")
 # Add this line to disable the specific warning
 add_compile_options(-Wno-missing-field-initializers)
 
+# Auto-load a local sdkconfig overlay (git-ignored) when present. Lets
+# self-hosted / custom deployments pin CONFIG_STACKCHAN_SERVER_URL,
+# CONFIG_OTA_URL, etc. without touching committed defaults.
+# Manual equivalent: SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.local" idf.py build
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/sdkconfig.defaults.local")
+    set(SDKCONFIG_DEFAULTS
+        "${CMAKE_CURRENT_SOURCE_DIR}/sdkconfig.defaults;${CMAKE_CURRENT_SOURCE_DIR}/sdkconfig.defaults.local"
+        CACHE STRING "ESP-IDF sdkconfig default files (auto-extended with local overlay)" FORCE)
+    message(STATUS "StackChan: detected sdkconfig.defaults.local, applying overlay")
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(stack-chan)


### PR DESCRIPTION
Detect firmware/sdkconfig.defaults.local at configure time and feed it
into ESP-IDF's SDKCONFIG_DEFAULTS list alongside sdkconfig.defaults.

This gives self-hosted and downstream builds a first-class way to pin
per-deployment values (CONFIG_STACKCHAN_SERVER_URL, CONFIG_OTA_URL,
CONFIG_USE_EZDATA, ...) without patching committed defaults and
without needing contributors to remember the
  SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.local"
invocation.

The file is ignored by the repo's .gitignore, so it never leaks
upstream. When it does not exist, behaviour is unchanged.

A status message ("StackChan: detected sdkconfig.defaults.local,
applying overlay") makes the override visible in the idf.py configure
output so it's obvious when a build is using custom defaults.
