### PR TITLE
fix(ios): scan for both Base and Alt BLE service UUIDs

### DIFF
--- a/app/StackChan/Utils/BlufiUtil.swift
+++ b/app/StackChan/Utils/BlufiUtil.swift
@@ -32,8 +32,14 @@ class BlufiUtil: NSObject,CBCentralManagerDelegate,CBPeripheralDelegate {
     
     var wifiSetCharacteristicCall: ((Data) -> Void)? = nil
     
-    /// Service UUID
-    private let targetServiceUUIDs: [CBUUID] = [CBUUID(string: "e2e5e5e0-1234-5678-1234-56789abcdef0")]
+    /// Service UUIDs. The firmware advertises two distinct 128-bit UUIDs:
+    /// - Base  (e2e5e5e0-...) exposed by startBleServer() — runtime control
+    /// - Alt   (e2e5e5ff-...) exposed by startAppConfigServer() — pairing/Wi-Fi setup
+    /// Scanning for both lets the app find the device in both modes.
+    private let targetServiceUUIDs: [CBUUID] = [
+        CBUUID(string: "e2e5e5e0-1234-5678-1234-56789abcdef0"),
+        CBUUID(string: "e2e5e5ff-1234-5678-1234-56789abcdef0"),
+    ]
     
     private let scanOptions: [String: Any] = [
         CBCentralManagerScanOptionAllowDuplicatesKey: true


### PR DESCRIPTION
The firmware publishes two distinct 128-bit service UUIDs depending on
which mode is active:

- e2e5e5e0-1234-5678-1234-56789abcdef0  (Base)
  Used by startBleServer() for runtime control (motion, avatar, RGB...)

- e2e5e5ff-1234-5678-1234-56789abcdef0  (Alt)
  Used by startAppConfigServer() for Wi-Fi provisioning / pairing

iOS scanForPeripherals(withServices:) only returns devices whose adv
payload contains the requested UUIDs, so scanning only the Base UUID
means the app is blind to the device whenever it is in Setup/pairing
mode - which is exactly when the app needs to connect to it.

Add both UUIDs to targetServiceUUIDs so the scan succeeds in either
mode. Observed behaviour before: BLE scan silently matched nothing,
user stays on "device offline" screen forever after scanning the QR.
