### PR TITLE
fix(ios): wire Wi-Fi config characteristic + actually push creds on Confirm

### DIFF
--- a/app/StackChan/AppState.swift
+++ b/app/StackChan/AppState.swift
@@ -76,15 +76,22 @@ class AppState: ObservableObject {
         }
         BlufiUtil.shared.characteristicCallback = { characteristic in
             if characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) {
-                
+
                 if characteristic.uuid.uuidString == "E2E5E5E2-1234-5678-1234-56789ABCDEF0" {
                     BlufiUtil.shared.writeExpressionCharacteristic = characteristic
                     print("✏️ Expression writable characteristic assigned: \(characteristic.uuid)")
                 }
-                
+
                 if characteristic.uuid.uuidString == "E2E5E5E1-1234-5678-1234-56789ABCDEF0" {
                     BlufiUtil.shared.writeHeadCharacteristic = characteristic
                     print("✏️ Head writable characteristic assigned: \(characteristic.uuid)")
+                }
+
+                // Config characteristic — used for Wi-Fi provisioning (SSID + password JSON)
+                // during pairing. Firmware handler is _handle_ble_config_write in hal_ble.cpp.
+                if characteristic.uuid.uuidString == "E2E5E5E3-1234-5678-1234-56789ABCDEF0" {
+                    BlufiUtil.shared.writeWifiSetCharacteristic = characteristic
+                    print("✏️ Config/Wifi writable characteristic assigned: \(characteristic.uuid)")
                 }
             }
         }

--- a/app/StackChan/View/BindingDevice.swift
+++ b/app/StackChan/View/BindingDevice.swift
@@ -279,23 +279,38 @@ struct ScanningEquipment : View {
     }
     
     private func confirmWifi() {
-        
+
         if !BlufiUtil.shared.blueSwitch {
             appState.alertTitle = "Please turn on Bluetooth"
             appState.showAlert = true
             return
         }
-        
+
         if wifiName.isEmpty || wifiPassword.isEmpty {
             appState.alertTitle = "Please enter Wi-Fi name and password"
             appState.showAlert = true
             return
         }
-        
+
+        // Push the Wi-Fi credentials to the StackChan over BLE.
+        // The firmware expects {"ssid":..., "password":...} on the Config
+        // characteristic (see hal_ble.cpp:_handle_ble_config_write).
+        let payload: [String: String] = [
+            "ssid": wifiName,
+            "password": wifiPassword,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let json = String(data: data, encoding: .utf8) {
+            BlufiUtil.shared.sendWifiSetData(json)
+            print("➡️ Wi-Fi credentials sent to device")
+        } else {
+            print("⚠️ Failed to serialise Wi-Fi payload")
+        }
+
         withAnimation{
             pairingStatus = .DistributionNetwork
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             withAnimation{
                 pairingStatus = .ChangeTheName


### PR DESCRIPTION
Two stub-level gaps in the open-source app prevented the pairing from
ever completing:

1. AppState.swift never maps the E2E5E5E3 (Config) characteristic to
   BlufiUtil.writeWifiSetCharacteristic. Without the mapping, any
   attempt to sendWifiSetData() early-returns with "No writable
   characteristic".

2. BindingDevice.confirmWifi() only flipped the pairingStatus to
   DistributionNetwork and then ChangeTheName after a 1s delay,
   without ever writing anything over BLE. The firmware never
   received the Wi-Fi credentials, the StackChan stayed offline.

Fix:
- Assign writeWifiSetCharacteristic when the E2E5E5E3 characteristic
  is discovered during the GATT service scan.
- Serialise {"ssid":..., "password":...} as JSON in confirmWifi and
  send it via BlufiUtil.sendWifiSetData before animating the UI
  progression. The firmware handler (hal_ble.cpp:
  _handle_ble_config_write) parses this exact shape.

Both fixes live on self-host for now; they should also land upstream.
