### PR TITLE
fix(ios): correct swapped deviceOnline/deviceOffline bool assignments

### DIFF
--- a/app/StackChan/AppState.swift
+++ b/app/StackChan/AppState.swift
@@ -251,9 +251,9 @@ class AppState: ObservableObject {
                 if let msgType = result.0 {
                     switch msgType {
                     case MsgType.deviceOnline:
-                        self.deviceIsOnline = false
-                    case MsgType.deviceOffline:
                         self.deviceIsOnline = true
+                    case MsgType.deviceOffline:
+                        self.deviceIsOnline = false
                     default:
                         break
                     }


### PR DESCRIPTION
In webSocketMessageMonitoring, the WS message handler was doing the
opposite of what the names imply:
- MsgType.deviceOnline  set deviceIsOnline = false
- MsgType.deviceOffline set deviceIsOnline = true

Obvious typo in the upstream code. Once the StackChan successfully
opened its avatar WS to the server, the server pushed a deviceOnline
notification to the App and the App mislabelled the status as offline.
