### PR TITLE
fix(firmware): include factory MAC in WS avatar URL query

### DIFF
--- a/firmware/main/hal/hal_ws_avatar.cpp
+++ b/firmware/main/hal/hal_ws_avatar.cpp
@@ -11,6 +11,7 @@
 #include <board.h>
 #include <web_socket.h>
 #include <esp_log.h>
+#include <esp_mac.h>
 #include <arpa/inet.h>
 #include <jpg/image_to_jpeg.h>
 #include <wifi_station.h>
@@ -63,7 +64,11 @@ public:
 
     void init()
     {
-        _url = fmt::format("{}/stackChan/ws?deviceType=StackChan", secret_logic::get_server_url());
+        uint8_t mac[6] = {0};
+        esp_read_mac(mac, ESP_MAC_EFUSE_FACTORY);
+        _url = fmt::format(
+            "{}/stackChan/ws?mac={:02X}{:02X}{:02X}{:02X}{:02X}{:02X}&deviceType=StackChan",
+            secret_logic::get_server_url(), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
         connect();
 


### PR DESCRIPTION
The server's web_socket.Handler rejects connections without both
'mac' and 'deviceType' query parameters (server/internal/web_socket/
web_socket.go:89-92):

    mac := r.Get(\"mac\").String()
    deviceType := r.Get(\"deviceType\").String()
    if mac == \"\" || deviceType == \"\" {
        r.Response.Write(\"The mac and deviceType parameters are empty.\")
        return
    }

Before this change, hal_ws_avatar built the URL with only
?deviceType=StackChan, so every WebSocket handshake was silently
rejected. Observable on-device as endless 'WS-Avatar: Failed to
connect' retries; observable server-side as a TCP connection that
upgrades, receives the upgrade request, and is abandoned without a
WS upgrade.

Read the factory MAC at init() and inject it in the URL, matching
the format the iOS app already uses:
  ?mac=441BF6E48694&deviceType=StackChan
