### PR TITLE
Add configurable AI Agent boot option

### DIFF
--- a/firmware/main/apps/app_setup/workers/ai_agent.cpp
+++ b/firmware/main/apps/app_setup/workers/ai_agent.cpp
@@ -207,9 +207,36 @@ XiaozhiGeneralWorker::XiaozhiGeneralWorker()
     _slider_idle_motion->setValue(current_index);
     _slider_idle_motion->onValueChanged().connect([this](int32_t value) { _pending_idle_motion_index = value; });
 
+    _panel_startup = std::make_unique<Container>(_panel->get());
+    _panel_startup->setSize(296, 120);
+    _panel_startup->align(LV_ALIGN_TOP_MID, 0, 196);
+    _panel_startup->setBgColor(lv_color_hex(0xD2E3FF));
+    _panel_startup->setBorderWidth(0);
+    _panel_startup->setRadius(18);
+    _panel_startup->setPadding(0, 0, 0, 0);
+    _panel_startup->removeFlag(LV_OBJ_FLAG_SCROLLABLE);
+
+    _label_startup_title = std::make_unique<Label>(_panel_startup->get());
+    _label_startup_title->setText("Start AI Agent on boot:");
+    _label_startup_title->setTextFont(&lv_font_montserrat_16);
+    _label_startup_title->setTextColor(lv_color_hex(0x26206A));
+    _label_startup_title->setWidth(260);
+    _label_startup_title->setTextAlign(LV_TEXT_ALIGN_CENTER);
+    _label_startup_title->align(LV_ALIGN_TOP_MID, 0, 18);
+
+    _switch_start_ai_on_boot = std::make_unique<Switch>(_panel_startup->get());
+    _switch_start_ai_on_boot->setSize(64, 36);
+    _switch_start_ai_on_boot->align(LV_ALIGN_TOP_MID, 0, 66);
+    _switch_start_ai_on_boot->setBgColor(lv_color_hex(0xB8D3FD), LV_PART_MAIN);
+    _switch_start_ai_on_boot->setBgColor(lv_color_hex(0x615B9E), LV_PART_INDICATOR | LV_STATE_CHECKED);
+    _switch_start_ai_on_boot->setBgColor(lv_color_hex(0xFFFFFF), LV_PART_KNOB);
+    if (_config.startAiAgentOnBoot) {
+        _switch_start_ai_on_boot->addState(LV_STATE_CHECKED);
+    }
+
     _btn_confirm = std::make_unique<Button>(_panel->get());
     apply_button_common_style(*_btn_confirm);
-    _btn_confirm->align(LV_ALIGN_TOP_MID, 0, 196);
+    _btn_confirm->align(LV_ALIGN_TOP_MID, 0, 326);
     _btn_confirm->setSize(290, 50);
     _btn_confirm->label().setText("Confirm");
     _btn_confirm->onClick().connect([this]() { _confirm_flag = true; });
@@ -227,6 +254,7 @@ void XiaozhiGeneralWorker::update()
 
     if (_confirm_flag) {
         _confirm_flag = false;
+        _config.startAiAgentOnBoot = _switch_start_ai_on_boot->getValue();
         GetHAL().setXiaozhiConfig(_config);
         mclog::tagInfo(_tag, "xiaozhi config updated: idleRandomMovementLevel={} ({})", _config.idleRandomMovementLevel,
                        _idle_motion_level_labels[_config.idleRandomMovementLevel]);

--- a/firmware/main/apps/app_setup/workers/workers.h
+++ b/firmware/main/apps/app_setup/workers/workers.h
@@ -341,9 +341,12 @@ private:
 
     std::unique_ptr<uitk::lvgl_cpp::Container> _panel;
     std::unique_ptr<uitk::lvgl_cpp::Container> _panel_general;
+    std::unique_ptr<uitk::lvgl_cpp::Container> _panel_startup;
     std::unique_ptr<uitk::lvgl_cpp::Label> _label_idle_motion_title;
     std::unique_ptr<uitk::lvgl_cpp::Label> _label_idle_motion_value;
     std::unique_ptr<uitk::lvgl_cpp::Slider> _slider_idle_motion;
+    std::unique_ptr<uitk::lvgl_cpp::Label> _label_startup_title;
+    std::unique_ptr<uitk::lvgl_cpp::Switch> _switch_start_ai_on_boot;
     std::unique_ptr<uitk::lvgl_cpp::Button> _btn_confirm;
 
     XiaozhiConfig_t _config;

--- a/firmware/main/hal/board/hal_bridge.cc
+++ b/firmware/main/hal/board/hal_bridge.cc
@@ -24,6 +24,7 @@ static constexpr std::string_view _xiaozhi_config_nvs_ns                        
 static constexpr std::string_view _xiaozhi_config_idle_shutdown_time_key           = "idle_sec";
 static constexpr std::string_view _xiaozhi_config_allow_shutdown_when_charging_key = "ext_pwr";
 static constexpr std::string_view _xiaozhi_config_idle_random_movement_key         = "idle_lv";
+static constexpr std::string_view _xiaozhi_config_start_ai_agent_on_boot_key       = "boot_ai";
 
 namespace hal_bridge {
 
@@ -129,6 +130,8 @@ XiaozhiConfig_t get_xiaozhi_config()
         settings.GetBool(_xiaozhi_config_allow_shutdown_when_charging_key.data(), config.allowShutdownWhenCharging);
     config.idleRandomMovementLevel =
         settings.GetInt(_xiaozhi_config_idle_random_movement_key.data(), config.idleRandomMovementLevel);
+    config.startAiAgentOnBoot =
+        settings.GetBool(_xiaozhi_config_start_ai_agent_on_boot_key.data(), config.startAiAgentOnBoot);
 
     return config;
 }
@@ -139,6 +142,7 @@ void set_xiaozhi_config(const XiaozhiConfig_t& config)
     settings.SetInt(_xiaozhi_config_idle_shutdown_time_key.data(), config.idleShutdownTimeSeconds);
     settings.SetBool(_xiaozhi_config_allow_shutdown_when_charging_key.data(), config.allowShutdownWhenCharging);
     settings.SetInt(_xiaozhi_config_idle_random_movement_key.data(), config.idleRandomMovementLevel);
+    settings.SetBool(_xiaozhi_config_start_ai_agent_on_boot_key.data(), config.startAiAgentOnBoot);
 }
 
 void app_play_sound(const std::string_view& sound)

--- a/firmware/main/hal/board/hal_bridge.h
+++ b/firmware/main/hal/board/hal_bridge.h
@@ -28,6 +28,7 @@ struct XiaozhiConfig_t {
     uint32_t idleShutdownTimeSeconds = 600;
     bool allowShutdownWhenCharging   = false;
     uint8_t idleRandomMovementLevel  = 2;
+    bool startAiAgentOnBoot          = false;
 };
 
 void lock();

--- a/firmware/main/hal/hal.cpp
+++ b/firmware/main/hal/hal.cpp
@@ -209,6 +209,7 @@ XiaozhiConfig_t Hal::getXiaozhiConfig()
         .idleShutdownTimeSeconds   = bridge_config.idleShutdownTimeSeconds,
         .allowShutdownWhenCharging = bridge_config.allowShutdownWhenCharging,
         .idleRandomMovementLevel   = bridge_config.idleRandomMovementLevel,
+        .startAiAgentOnBoot        = bridge_config.startAiAgentOnBoot,
     };
 }
 
@@ -218,6 +219,7 @@ void Hal::setXiaozhiConfig(XiaozhiConfig_t config)
         .idleShutdownTimeSeconds   = config.idleShutdownTimeSeconds,
         .allowShutdownWhenCharging = config.allowShutdownWhenCharging,
         .idleRandomMovementLevel   = config.idleRandomMovementLevel,
+        .startAiAgentOnBoot        = config.startAiAgentOnBoot,
     });
 }
 

--- a/firmware/main/hal/hal.h
+++ b/firmware/main/hal/hal.h
@@ -118,6 +118,7 @@ struct XiaozhiConfig_t {
     uint32_t idleShutdownTimeSeconds = 600;
     bool allowShutdownWhenCharging   = false;
     uint8_t idleRandomMovementLevel  = 2;
+    bool startAiAgentOnBoot          = false;
 };
 
 /**

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -26,31 +26,36 @@ extern "C" void app_main(void)
     ui_hal::on_delay([](uint32_t ms) { GetHAL().delay(ms); });
     ui_hal::on_get_tick([]() { return GetHAL().millis(); });
 
-    // Install apps
-    GetMooncake().installApp(std::make_unique<AppLauncher>());
-    GetMooncake().installApp(std::make_unique<AppAiAgent>());
-    GetMooncake().installApp(std::make_unique<AppAvatar>());
-    GetMooncake().installApp(std::make_unique<AppEspnowControl>());
-    GetMooncake().installApp(std::make_unique<AppAppCenter>());
-    GetMooncake().installApp(std::make_unique<AppEzdata>());
-    GetMooncake().installApp(std::make_unique<AppDance>());
-    GetMooncake().installApp(std::make_unique<AppSetup>());
+    const bool skip_mooncake =
+        GetHAL().getXiaozhiConfig().startAiAgentOnBoot && GetHAL().getWarmRebootTarget() < 0;
 
-    // Main loop
-    while (1) {
-        GetHAL().feedTheDog();
-        GetHAL().updateHeapStatusLog();
+    if (!skip_mooncake) {
+        // Install apps
+        GetMooncake().installApp(std::make_unique<AppLauncher>());
+        GetMooncake().installApp(std::make_unique<AppAiAgent>());
+        GetMooncake().installApp(std::make_unique<AppAvatar>());
+        GetMooncake().installApp(std::make_unique<AppEspnowControl>());
+        GetMooncake().installApp(std::make_unique<AppAppCenter>());
+        GetMooncake().installApp(std::make_unique<AppEzdata>());
+        GetMooncake().installApp(std::make_unique<AppDance>());
+        GetMooncake().installApp(std::make_unique<AppSetup>());
 
-        GetMooncake().update();
+        // Main loop
+        while (1) {
+            GetHAL().feedTheDog();
+            GetHAL().updateHeapStatusLog();
 
-        if (GetHAL().isXiaozhiStartRequested()) {
-            break;
+            GetMooncake().update();
+
+            if (GetHAL().isXiaozhiStartRequested()) {
+                break;
+            }
         }
-    }
 
-    // Uninstall all apps and destroy mooncake
-    GetMooncake().uninstallAllApps();
-    DestroyMooncake();
+        // Uninstall all apps and destroy mooncake
+        GetMooncake().uninstallAllApps();
+        DestroyMooncake();
+    }
 
     // Start xiaozhi, never returns
     GetHAL().startXiaozhi();


### PR DESCRIPTION
Based on my personal experience playing with the device I think an option to skip mooncake altogether would be beneficial.

This just shows a toggle inside the AI Agent General settings (next to the slide for idle movement) to skip loading mooncake altogether.

<img width="1419" height="1674" alt="20260603_110605" src="https://github.com/user-attachments/assets/9884f9f3-8c5e-4db9-ba05-3560f9591c79" />
