### PR TITLE
Feature/ai agent boot direct 

### DIFF
--- a/firmware/main/apps/app_launcher/app_launcher.cpp
+++ b/firmware/main/apps/app_launcher/app_launcher.cpp
@@ -12,6 +12,10 @@
 
 using namespace mooncake;
 
+namespace {
+constexpr int kAiAgentAppId = 1;
+}
+
 void AppLauncher::onLauncherCreate()
 {
     mclog::tagInfo(getAppInfo().name, "on create");
@@ -26,6 +30,13 @@ void AppLauncher::onLauncherOpen()
 
     LvglLockGuard lock;
 
+    if (GetHAL().getXiaozhiConfig().startAiAgentOnBoot) {
+        mclog::tagInfo(getAppInfo().name, "ai agent boot requested, open ai agent directly");
+        _direct_ai_agent_requested = true;
+        open_ai_agent_if_requested();
+        return;
+    }
+
     if (!_startup_checked && !GetHAL().isAppConfiged()) {
         mclog::tagInfo(getAppInfo().name, "app not configured, start startup worker");
         _startup_worker = std::make_unique<setup_workers::StartupWorker>();
@@ -37,6 +48,10 @@ void AppLauncher::onLauncherOpen()
 void AppLauncher::onLauncherRunning()
 {
     LvglLockGuard lock;
+
+    if (_direct_ai_agent_requested) {
+        return;
+    }
 
     if (_startup_worker) {
         _startup_worker->update();
@@ -75,6 +90,16 @@ void AppLauncher::create_launcher_view()
         mclog::tagInfo(getAppInfo().name, "handle open app, app id: {}", appID);
         openApp(appID);
     };
+}
+
+void AppLauncher::open_ai_agent_if_requested()
+{
+    if (!_direct_ai_agent_requested) {
+        return;
+    }
+
+    _direct_ai_agent_requested = false;
+    openApp(kAiAgentAppId);
 }
 
 void AppLauncher::screensaver_update()

--- a/firmware/main/apps/app_launcher/app_launcher.cpp
+++ b/firmware/main/apps/app_launcher/app_launcher.cpp
@@ -12,10 +12,6 @@
 
 using namespace mooncake;
 
-namespace {
-constexpr int kAiAgentAppId = 1;
-}
-
 void AppLauncher::onLauncherCreate()
 {
     mclog::tagInfo(getAppInfo().name, "on create");
@@ -30,16 +26,16 @@ void AppLauncher::onLauncherOpen()
 
     LvglLockGuard lock;
 
-    if (GetHAL().getXiaozhiConfig().startAiAgentOnBoot) {
-        mclog::tagInfo(getAppInfo().name, "ai agent boot requested, open ai agent directly");
-        _direct_ai_agent_requested = true;
-        open_ai_agent_if_requested();
-        return;
-    }
-
     if (!_startup_checked && !GetHAL().isAppConfiged()) {
         mclog::tagInfo(getAppInfo().name, "app not configured, start startup worker");
         _startup_worker = std::make_unique<setup_workers::StartupWorker>();
+        return;
+    }
+
+    if (GetHAL().getXiaozhiConfig().startAiAgentOnBoot) {
+        mclog::tagInfo(getAppInfo().name, "ai agent boot requested, open ai agent directly");
+        _boot_ai_agent_requested = true;
+        create_launcher_view();
     } else {
         create_launcher_view();
     }
@@ -49,7 +45,8 @@ void AppLauncher::onLauncherRunning()
 {
     LvglLockGuard lock;
 
-    if (_direct_ai_agent_requested) {
+    if (_boot_ai_agent_requested) {
+        open_ai_agent_if_requested();
         return;
     }
 
@@ -94,12 +91,22 @@ void AppLauncher::create_launcher_view()
 
 void AppLauncher::open_ai_agent_if_requested()
 {
-    if (!_direct_ai_agent_requested) {
+    if (!_boot_ai_agent_requested) {
         return;
     }
 
-    _direct_ai_agent_requested = false;
-    openApp(kAiAgentAppId);
+    _boot_ai_agent_requested = false;
+
+    for (const auto& props : getAppProps()) {
+        if (props.info.name == "AI.AGENT") {
+            mclog::tagInfo(getAppInfo().name, "opening app by name: {}", props.info.name);
+            openApp(props.appID);
+            return;
+        }
+    }
+
+    mclog::tagError(getAppInfo().name, "AI.Agent app not found, fall back to launcher");
+    create_launcher_view();
 }
 
 void AppLauncher::screensaver_update()

--- a/firmware/main/apps/app_launcher/app_launcher.h
+++ b/firmware/main/apps/app_launcher/app_launcher.h
@@ -25,7 +25,9 @@ private:
     std::unique_ptr<setup_workers::StartupWorker> _startup_worker;
     uint32_t _screensaver_timecount = 0;
     bool _startup_checked           = false;
+    bool _direct_ai_agent_requested = false;
 
     void create_launcher_view();
+    void open_ai_agent_if_requested();
     void screensaver_update();
 };

--- a/firmware/main/apps/app_launcher/app_launcher.h
+++ b/firmware/main/apps/app_launcher/app_launcher.h
@@ -25,7 +25,7 @@ private:
     std::unique_ptr<setup_workers::StartupWorker> _startup_worker;
     uint32_t _screensaver_timecount = 0;
     bool _startup_checked           = false;
-    bool _direct_ai_agent_requested = false;
+    bool _boot_ai_agent_requested   = false;
 
     void create_launcher_view();
     void open_ai_agent_if_requested();

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -26,8 +26,7 @@ extern "C" void app_main(void)
     ui_hal::on_delay([](uint32_t ms) { GetHAL().delay(ms); });
     ui_hal::on_get_tick([]() { return GetHAL().millis(); });
 
-    const bool skip_mooncake =
-        GetHAL().getXiaozhiConfig().startAiAgentOnBoot && GetHAL().getWarmRebootTarget() < 0;
+    const bool skip_mooncake = GetHAL().getWarmRebootTarget() < 0 && !GetHAL().getXiaozhiConfig().startAiAgentOnBoot;
 
     if (!skip_mooncake) {
         // Install apps


### PR DESCRIPTION
This PR adds support for launching the AI Agent app directly at boot when startAiAgentOnBoot is enabled.

Instead of staying on the launcher screen, the device automatically opens the AI Agent app after startup.

Changes
Added direct AI Agent launch flow in AppLauncher
Added _direct_ai_agent_requested state handling
Added open_ai_agent_if_requested()
Updated boot condition logic in main.cpp
Preserved existing launcher behavior when boot option is disabled
Behavior

Before:

Device boots into launcher UI

After (startAiAgentOnBoot=true):

Device boots directly into AI Agent mode
Notes
AI Agent app currently uses fixed app id 1
Existing behavior remains unchanged when the option is disabled