### PR TITLE
Fix Flutter Android build and login error handling

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -30,3 +30,16 @@ subprojects {
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
+
+// STACKCHAN_TFLITE_JVM_FIX
+// tflite_flutter kompiluje Java do JVM 11,
+// dlatego Kotlin tego modułu również musi używać JVM 11.
+subprojects {
+    if (name == "tflite_flutter") {
+        tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+            compilerOptions.jvmTarget.set(
+                org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+            )
+        }
+    }
+}

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -2,13 +2,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 
-# 新增的代理配置（127.0.0.1:7897）
-# HTTP代理
-systemProp.http.proxyHost=127.0.0.1
-systemProp.http.proxyPort=7897
-# HTTPS代理（必须配置，Android依赖多为HTTPS）
-systemProp.https.proxyHost=127.0.0.1
-systemProp.https.proxyPort=7897
-# 可选：无需走代理的地址（本地/内网地址，按需调整）
-systemProp.http.nonProxyHosts=localhost,127.0.0.1,192.168.*,*.local
-systemProp.https.nonProxyHosts=localhost,127.0.0.1,192.168.*,*.local
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/app/lib/network/http.dart
+++ b/app/lib/network/http.dart
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:stack_chan/app_state.dart';
 import 'package:stack_chan/network/urls.dart';
 import 'package:stack_chan/network/web_socket_util.dart';
@@ -18,7 +17,7 @@ void logPrint(Object? object) {
   const int chunkSize = 800; //800（limit）
   //ifcontent,directPrint
   if (log.length <= chunkSize) {
-        return;
+    return;
   }
 
   //contentPrint
@@ -26,7 +25,7 @@ void logPrint(Object? object) {
     int end = i + chunkSize;
     if (end > log.length) end = log.length;
     //usedebugPrint(print,supportcontent)
-      }
+  }
 }
 
 class Http {
@@ -41,11 +40,21 @@ class Http {
     InterceptorsWrapper(
       onRequest:
           (RequestOptions options, RequestInterceptorHandler handler) async {
-            /// v1 mac
-            final encryptedToken = RsaUtil.encrypt(
-              WebSocketUtil.shared.getAuthorization(AppState.shared.deviceMac),
-            );
-            options.headers[ValueConstant.authorization] = encryptedToken;
+            /// v1 mac — RSA-encrypted authorization header.
+            /// Only attach it when RSA keys are actually configured. The
+            /// public repo ships empty placeholder keys, and the login /
+            /// registration endpoints don't require this header (the server
+            /// whitelists them in V2TokenAuthMiddleware). Skipping it here
+            /// prevents a FormatException before every request. Post-login /
+            /// device flows still send it once real keys are provided.
+            if (RsaUtil.isConfigured) {
+              final encryptedToken = RsaUtil.encrypt(
+                WebSocketUtil.shared.getAuthorization(
+                  AppState.shared.deviceMac,
+                ),
+              );
+              options.headers[ValueConstant.authorization] = encryptedToken;
+            }
 
             /// v2 token
             final token = await AppState.asyncPrefs.getString(
@@ -65,11 +74,11 @@ class Http {
           },
       onResponse:
           (Response response, ResponseInterceptorHandler handler) async {
-        if (response.statusCode == 401) {
-          await AppState.shared.logout();
-        }
-        return handler.next(response);
-      },
+            if (response.statusCode == 401) {
+              await AppState.shared.logout();
+            }
+            return handler.next(response);
+          },
       onError: (DioException error, ErrorInterceptorHandler handler) async {
         if (error.response?.statusCode == 401) {
           await AppState.shared.logout();

--- a/app/lib/network/urls.dart
+++ b/app/lib/network/urls.dart
@@ -21,8 +21,16 @@ class Urls {
   /// Example: "192.168.1.100:8080/" or "api.example.com/"
   ///
   /// For development, you can use the commented local IP below
-  static const String url = "00.000.000.000:0000/";
+  static const String placeholderUrl = "00.000.000.000:0000/";
+  static const String url = placeholderUrl;
 
+  static bool get isConfigured {
+    final value = url.trim();
+
+    return value.isNotEmpty &&
+        value != placeholderUrl &&
+        !value.contains("00.000.000.000");
+  }
 
   /// Get the HTTP base URL for API requests
   ///
@@ -144,5 +152,6 @@ class Urls {
 
   /// Generate license token for device activation
   /// Used for StackChan device licensing and activation
-  static const String xiaozhiGenerateLicenseToken = "xiaozhi/generateLicenseToken";
+  static const String xiaozhiGenerateLicenseToken =
+      "xiaozhi/generateLicenseToken";
 }

--- a/app/lib/util/rsa_util.dart
+++ b/app/lib/util/rsa_util.dart
@@ -8,31 +8,43 @@ import 'package:pointycastle/asymmetric/api.dart';
 import 'package:stack_chan/util/value_constant.dart';
 
 class RsaUtil {
-  static final _encrypter = Encrypter(
-    RSA(
-      publicKey:
-          RSAKeyParser().parse(ValueConstant.serverPublicKey) as RSAPublicKey,
-      privateKey:
-          RSAKeyParser().parse(ValueConstant.clientPrivateKey) as RSAPrivateKey,
-      encoding: RSAEncoding.OAEP,
-      digest: RSADigest.SHA256,
-    ),
-  );
+  /// True only when both keys used by the server/client RSA channel are present.
+  static bool get isConfigured =>
+      ValueConstant.serverPublicKey.trim().isNotEmpty &&
+      ValueConstant.clientPrivateKey.trim().isNotEmpty;
 
-  ///RSA Encrypt（OAEP + SHA-256）
-  static String encrypt(String plainText) {
-    final encrypted = _encrypter.encrypt(plainText);
-    return encrypted.base64;
+  static bool get isStackChanBlueConfigured =>
+      ValueConstant.stackChanBluePrivateKey.trim().isNotEmpty;
+
+  static Encrypter? _encrypter;
+  static Encrypter? _stackChanBlueEncrypter;
+
+  static Encrypter get _configuredEncrypter {
+    if (!isConfigured) {
+      throw const FormatException('RSA keys are not configured.');
+    }
+
+    return _encrypter ??= Encrypter(
+      RSA(
+        publicKey:
+            RSAKeyParser().parse(ValueConstant.serverPublicKey) as RSAPublicKey,
+        privateKey:
+            RSAKeyParser().parse(ValueConstant.clientPrivateKey)
+                as RSAPrivateKey,
+        encoding: RSAEncoding.OAEP,
+        digest: RSADigest.SHA256,
+      ),
+    );
   }
 
-  ///RSA Decrypt（OAEP + SHA-256）
-  static String decrypt(String cipherText) {
-    final encrypted = Encrypted.fromBase64(cipherText);
-    return _encrypter.decrypt(encrypted);
-  }
+  static Encrypter get _configuredStackChanBlueEncrypter {
+    if (!isStackChanBlueConfigured) {
+      throw const FormatException(
+        'StackChan Bluetooth RSA key is not configured.',
+      );
+    }
 
-  static String decryptStackChanBlue(String cipherText) {
-    final stackChanBlueEncrypter = Encrypter(
+    return _stackChanBlueEncrypter ??= Encrypter(
       RSA(
         privateKey:
             RSAKeyParser().parse(ValueConstant.stackChanBluePrivateKey)
@@ -41,7 +53,22 @@ class RsaUtil {
         digest: RSADigest.SHA256,
       ),
     );
+  }
+
+  ///RSA Encrypt（OAEP + SHA-256）
+  static String encrypt(String plainText) {
+    final encrypted = _configuredEncrypter.encrypt(plainText);
+    return encrypted.base64;
+  }
+
+  ///RSA Decrypt（OAEP + SHA-256）
+  static String decrypt(String cipherText) {
     final encrypted = Encrypted.fromBase64(cipherText);
-    return stackChanBlueEncrypter.decrypt(encrypted);
+    return _configuredEncrypter.decrypt(encrypted);
+  }
+
+  static String decryptStackChanBlue(String cipherText) {
+    final encrypted = Encrypted.fromBase64(cipherText);
+    return _configuredStackChanBlueEncrypter.decrypt(encrypted);
   }
 }

--- a/app/lib/view/popup/login_page.dart
+++ b/app/lib/view/popup/login_page.dart
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2026 M5Stack Technology CO LTD
 SPDX-License-Identifier: MIT
 */
 
+import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -66,63 +67,85 @@ class _LoginPageState extends State<LoginPage> {
   void dispose() {
     nameTextEditingController.dispose();
     passwordTextEditingController.dispose();
-    if (mounted) {
-      FocusScope.of(context).unfocus();
-    }
     super.dispose();
   }
 
   Future<void> login() async {
+    // Guard against double taps starting several requests.
     if (loading.value) {
       return;
     }
-    loading.value = true;
+    // Validate before showing the spinner so a validation error never hides
+    // the form behind an endless spinner.
     if (username.isEmpty) {
       AppState.shared.showToast(
         "Please enter your account number or email address.",
       );
-      loading.value = false;
       return;
     }
     if (password.isEmpty) {
       AppState.shared.showToast("Please enter the password.");
-      loading.value = false;
       return;
     }
-    final Map<String, dynamic> map = {
-      ValueConstant.username: username,
-      ValueConstant.password: password,
-    };
-    final response = await Http.instance.post(Urls.login, data: map);
-    if (response.data != null) {
-      Model<LoginResponseModel> responseData = Model.fromJsonT(
-        response.data,
-        factory: (value) => LoginResponseModel.fromJson(value),
-      );
-      if (responseData.isSuccess()) {
-        final token = responseData.data?.token;
-        if (token != null) {
-          AppState.shared.setIsLogin(true);
-          await AppState.asyncPrefs.setString(ValueConstant.token, token);
-          AppState.shared.showToast("Login successful");
-          if (mounted) {
-            AppState.shared.getUserInfo();
-            AppState.shared.getDevices();
-            if (widget.isWelCome != true) {
-              CupertinoSheetRoute.popSheet(context);
-            } else {
-              Navigator.of(context).pop();
+
+    loading.value = true;
+    try {
+      final Map<String, dynamic> map = {
+        ValueConstant.username: username,
+        ValueConstant.password: password,
+      };
+      final response = await Http.instance.post(Urls.login, data: map);
+      // --- existing server-response handling (unchanged) ---
+      if (response.data != null) {
+        Model<LoginResponseModel> responseData = Model.fromJsonT(
+          response.data,
+          factory: (value) => LoginResponseModel.fromJson(value),
+        );
+        if (responseData.isSuccess()) {
+          final token = responseData.data?.token;
+          if (token != null) {
+            AppState.shared.setIsLogin(true);
+            await AppState.asyncPrefs.setString(ValueConstant.token, token);
+            AppState.shared.showToast("Login successful");
+            if (mounted) {
+              AppState.shared.getUserInfo();
+              AppState.shared.getDevices();
+              if (widget.isWelCome != true) {
+                CupertinoSheetRoute.popSheet(context);
+              } else {
+                Navigator.of(context).pop();
+              }
+              BlueUtil.shared.cachedDeviceMacs = [];
             }
-            BlueUtil.shared.cachedDeviceMacs = [];
           }
+        } else {
+          showLoginErrMessage(responseData.message);
         }
       } else {
-        showLoginErrMessage(responseData.message);
+        AppState.shared.showToast(response.statusMessage);
       }
-    } else {
-      AppState.shared.showToast(response.statusMessage);
+    } on FormatException catch (error, stackTrace) {
+      // e.g. RSA key parsing when encryption keys are not configured.
+      debugPrint("Login configuration/format error: $error");
+      debugPrintStack(stackTrace: stackTrace);
+      AppState.shared.showToast(
+        "The application encryption keys are not configured.",
+      );
+    } on DioException catch (error, stackTrace) {
+      // Network / server errors (timeout, DNS, TLS, HTTP status, bad body).
+      debugPrint("Login network error: ${error.type}");
+      debugPrintStack(stackTrace: stackTrace);
+      AppState.shared.showToast(
+        "Login failed. Check the internet connection or server configuration.",
+      );
+    } catch (error, stackTrace) {
+      debugPrint("Unexpected login error: $error");
+      debugPrintStack(stackTrace: stackTrace);
+      AppState.shared.showToast("An unexpected login error occurred.");
+    } finally {
+      // Always release the spinner, whatever happened above.
+      loading.value = false;
     }
-    loading.value = false;
   }
 
   void showLoginErrMessage(String? text) {

--- a/app/lib/view/popup/login_page.dart
+++ b/app/lib/view/popup/login_page.dart
@@ -88,6 +88,11 @@ class _LoginPageState extends State<LoginPage> {
       return;
     }
 
+    if (!Urls.isConfigured) {
+      AppState.shared.showToast("Backend server is not configured.");
+      return;
+    }
+
     loading.value = true;
     try {
       final Map<String, dynamic> map = {

--- a/app/lib/view/util/stack_chan_rotary_robot_box.dart
+++ b/app/lib/view/util/stack_chan_rotary_robot_box.dart
@@ -272,7 +272,7 @@ class _StackChanRotaryRobotJsState extends State<StackChanRotaryRobotJs> {
     if (byteData != null) {
       //convertas three_js Uint8Array
       final uint8List = byteData.buffer.asUint8List();
-      final nativeArray = three.Uint8Array.fromList(uint8List);
+      final nativeArray = uint8List;
 
       //updatetexture
       expressionTexture.image = three.ImageElement(

--- a/app/lib/view/util/stackchan_robot_box.dart
+++ b/app/lib/view/util/stackchan_robot_box.dart
@@ -418,7 +418,7 @@ class _StackchanRobotThreeState extends State<StackchanRobotJs> {
     if (byteData != null) {
       //convertas three_js Uint8Array
       final uint8List = byteData.buffer.asUint8List();
-      final nativeArray = three.Uint8Array.fromList(uint8List);
+      final nativeArray = uint8List;
 
       //updatetexture
       expressionTexture!.image = three.ImageElement(


### PR DESCRIPTION
## Summary

This pull request fixes several issues preventing the Flutter app from building and using the login form correctly on newer Android devices, including Samsung phones.

## Changes

### Login form and keyboard

- Fixes software keyboard and text input behavior on Samsung Android devices.
- Removes an unsafe `FocusScope.of(context)` call from `dispose()`.
- Ensures the loading state is always reset with `try/catch/finally`.
- Adds controlled handling for connection errors.

### RSA handling

- Prevents parsing empty or placeholder RSA keys.
- Uses lazy RSA encrypter initialization.
- Separates Bluetooth key validation from HTTP RSA validation.
- Prevents `FormatException: Unable to parse key, invalid format`.

### Android build

- Configures the `tflite_flutter` Kotlin compilation target to JVM 11.
- Limits the workaround to the affected plugin.
- Removes obsolete localhost proxy configuration.

### Three.js compatibility

- Uses Dart `Uint8List` directly for texture image data.
- Fixes compatibility with the current `three_js_core` API.

### Missing backend configuration

- Detects the placeholder backend address:
  `00.000.000.000:0000/`
- Prevents login credentials from being sent when the backend is not configured.
- Shows:
  `Backend server is not configured.`

## Testing

Tested on a physical Samsung Galaxy S21 Ultra.

- `dart format` passed.
- `flutter analyze` reported no compilation errors.
- `flutter build apk --debug` succeeded.
- APK installed and launched successfully.
- Software keyboard opens and text fields accept input.
- No RSA parsing crash.
- No dispose-related crash.
- No endless loading spinner.
- Placeholder backend is detected before an HTTP client is created.
- Automated login-form guard test passed.

## Notes

The repository still contains a placeholder backend address and does not provide a supported production backend configuration for source builds.

This pull request does not add private keys, tokens, production URLs, credentials, or server secrets.