### PR TITLE
fix(firmware): reject malformed setWifi and keep the WiFi password out of the log

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -63,5 +63,6 @@ obj/
 
 sdkconfig
 sdkconfig.old
+sdkconfig.defaults.local
 
 xiaozhi-esp32/

--- a/firmware/main/hal/hal_ble.cpp
+++ b/firmware/main/hal/hal_ble.cpp
@@ -464,6 +464,12 @@ private:
         const char* ssid     = data["ssid"];
         const char* password = data["password"];
 
+        if (ssid == nullptr || password == nullptr) {
+            mclog::tagWarn(_tag, "setWifi is missing ssid or password");
+            notify_state(2, "wifiConnectFailed");
+            return;
+        }
+
         mclog::tagInfo(_tag, "get wifi config: {} / {}", ssid, password);
 
         // Notify state: connecting

--- a/firmware/main/hal/hal_ble.cpp
+++ b/firmware/main/hal/hal_ble.cpp
@@ -470,7 +470,7 @@ private:
             return;
         }
 
-        mclog::tagInfo(_tag, "get wifi config: {} / {}", ssid, password);
+        mclog::tagInfo(_tag, "get wifi config for ssid: {}", ssid);
 
         // Notify state: connecting
         notify_state(0, "wifiConnecting");


### PR DESCRIPTION
## Problem

`WifiConfigServer::handle_set_wifi()` reads the two fields of a `setWifi` message into `const char*`:

```cpp
const char* ssid     = data["ssid"];
const char* password = data["password"];

mclog::tagInfo(_tag, "get wifi config: {} / {}", ssid, password);
```

ArduinoJson returns `nullptr` for a missing key. Both values are then formatted into the log and passed to `connect_wifi()`, which takes `std::string` parameters, so a `setWifi` message that omits either field aborts the device. Nothing is sent back to the app, so it sits on `wifiConnecting` until it times out.

The same log line also writes the WiFi password to the serial console in clear text.

## Changes

- Reject a `setWifi` message with a missing `ssid` or `password`, and answer `wifiConnectFailed` so the app can show its error dialog instead of waiting.
- Log only the SSID.
- Add `sdkconfig.defaults.local` to `.gitignore`. `firmware/CMakeLists.txt` loads that overlay automatically when it exists, which makes it the natural place for per-deployment settings such as `CONFIG_STACKCHAN_SERVER_URL`, but it is currently tracked and easy to commit by accident.

## How this was tested

On a StackChan (CoreS3, ESP-IDF v5.5.4), sending `{"cmd":"setWifi","data":{}}` to the config characteristic `e2e5e5e3-1234-5678-1234-56789abcdef0` with a small Python BLE client that speaks the protocol directly.

Before:

```
abort() was called at PC 0x421fcd63 on core 0
Backtrace: 0x4038ef11:0x3fcbfad0 0x4038eed9:0x3fcbfaf0 0x40396b66:0x3fcbfb10 ...
Rebooting...
```

The client received no reply.

After:

```
[WifiConfigServer] setWifi is missing ssid or password
[HAL-BLE] Config notify fragmented notify: total=67, mtu_payload=27, chunk_payload=17, packets=4
NimBLE: notify_tx event; conn_handle=1 attr_handle=22 status=0 is_indication=0   (x4)
```

The client decoded `wifiConnectFailed` and the device stayed up.

A well-formed `setWifi` still connects normally; that path is unchanged.
